### PR TITLE
Fix the Procfile web gunicorn pointing to wrong wsgi file

### DIFF
--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,2 +1,2 @@
 release: playwright install --with-deps chromium
-web: gunicorn backend.wsgi
+web: gunicorn config.wsgi


### PR DESCRIPTION
- [x] Change the web gunicorn to point to config.wsgl instead of backend.wsgl folder