### PR TITLE
fix(scraper): refactor ScraperBookFetcher and update tests

### DIFF
--- a/backend/tests/unit/test_scraper_book_fetcher.py
+++ b/backend/tests/unit/test_scraper_book_fetcher.py
@@ -7,12 +7,19 @@ from config.constants import SCRAPPING_ELEMENTS
 @pytest.mark.django_db
 class TestScraperBookFetcher:
     @patch("services.strategies.scraper_book_fetcher.get_browser")
-    def test_fetch_success(self, mock_browser):
+    def test_fetch_success(self, mock_get_browser):
         """
         Test successful scraping with title, author, and cover image.
         """
         mock_page = MagicMock()
-        mock_browser.return_value.new_page.return_value = mock_page
+        mock_browser = MagicMock()
+        mock_playwright = MagicMock()
+
+        # Make get_browser return (browser, playwright)
+        mock_get_browser.return_value = (mock_browser, mock_playwright)
+
+        # new_page returns mock page
+        mock_browser.new_page.return_value = mock_page
 
         # Mock title & author selectors
         def mock_inner_text(selector):
@@ -23,32 +30,38 @@ class TestScraperBookFetcher:
             return ""
 
         mock_page.inner_text.side_effect = mock_inner_text
-        # Simulate a cover image found
         mock_page.get_attribute.return_value = "//images.example.com/cover.jpg"
 
         fetcher = ScraperBookFetcher()
         result = fetcher.fetch("111")
 
-        # ✅ Assertions
+        # Assertions on scraped data
         assert "items" in result
         assert result["items"][0]["title"] == "Test Title"
         assert result["items"][0]["authors"] == ["Test Author"]
         assert result["items"][0]["imageLinks"]["smallThumbnail"].startswith("https:")
 
-        # Ensure browser/page methods were used
-        mock_browser.return_value.new_page.assert_called_once()
+        # Assertions on browser/page lifecycle
+        mock_browser.new_page.assert_called_once()
         mock_page.goto.assert_called_once()
         mock_page.close.assert_called_once()
+        mock_browser.close.assert_called_once()
+        mock_playwright.stop.assert_called_once()
 
     @patch("services.strategies.scraper_book_fetcher.get_browser")
-    def test_fetch_404_page(self, mock_browser):
+    def test_fetch_404_page(self, mock_get_browser):
         """
-        Test when scraping returns empty items.
+        Test when scraping returns 404.
+        Should return empty items.
         """
         mock_page = MagicMock()
-        mock_browser.return_value.new_page.return_value = mock_page
+        mock_browser = MagicMock()
+        mock_playwright = MagicMock()
 
-        # Simulate 404 message being found
+        mock_get_browser.return_value = (mock_browser, mock_playwright)
+        mock_browser.new_page.return_value = mock_page
+
+        # Simulate 404 page
         mock_page.locator().inner_text.return_value = "404 - Page Not Found"
 
         fetcher = ScraperBookFetcher()
@@ -56,17 +69,23 @@ class TestScraperBookFetcher:
 
         assert result == {"items": []}
 
-        # Ensure page was closed even after 404
+        # Ensure page/browser/playwright are closed
         mock_page.close.assert_called_once()
+        mock_browser.close.assert_called_once()
+        mock_playwright.stop.assert_called_once()
 
     @patch("services.strategies.scraper_book_fetcher.get_browser")
-    def test_fetch_scraping_error(self, mock_browser):
+    def test_fetch_scraping_error(self, mock_get_browser):
         """
         Test unexpected error while scraping.
         Should gracefully return empty items.
         """
         mock_page = MagicMock()
-        mock_browser.return_value.new_page.return_value = mock_page
+        mock_browser = MagicMock()
+        mock_playwright = MagicMock()
+
+        mock_get_browser.return_value = (mock_browser, mock_playwright)
+        mock_browser.new_page.return_value = mock_page
 
         # Simulate scraping failure
         mock_page.inner_text.side_effect = Exception("Scraping failed")
@@ -76,17 +95,23 @@ class TestScraperBookFetcher:
 
         assert result == {"items": []}
 
-        # Ensure page was closed even after error
+        # Ensure page/browser/playwright are closed
         mock_page.close.assert_called_once()
+        mock_browser.close.assert_called_once()
+        mock_playwright.stop.assert_called_once()
 
     @patch("services.strategies.scraper_book_fetcher.get_browser")
-    def test_fetch_no_cover_image(self, mock_browser):
+    def test_fetch_no_cover_image(self, mock_get_browser):
         """
         Test when no cover image available.
         Should still return book data with empty image link.
         """
         mock_page = MagicMock()
-        mock_browser.return_value.new_page.return_value = mock_page
+        mock_browser = MagicMock()
+        mock_playwright = MagicMock()
+
+        mock_get_browser.return_value = (mock_browser, mock_playwright)
+        mock_browser.new_page.return_value = mock_page
 
         # Return valid title & author
         def mock_inner_text(selector):
@@ -106,5 +131,7 @@ class TestScraperBookFetcher:
         # Image link should be empty
         assert result["items"][0]["imageLinks"]["smallThumbnail"] == ""
 
-        # Ensure page was closed
+        # Ensure page/browser/playwright are closed
         mock_page.close.assert_called_once()
+        mock_browser.close.assert_called_once()
+        mock_playwright.stop.assert_called_once()


### PR DESCRIPTION
- Updated ScraperBookFetcher to use per-request browser lifecycle to avoid greenlet/threading errors in Django views.
- Refactored unit tests to mock get_browser() returning (browser, playwright) and assert proper cleanup of page, browser, and playwright.
- Ensures 404, scraping errors, and missing cover image are properly tested.